### PR TITLE
Fix paths

### DIFF
--- a/src/WkFile.php
+++ b/src/WkFile.php
@@ -114,7 +114,7 @@ class WkFile {
 
 		$file = new $fileClass();
 		$file->setFromLocalFile(
-			$this->getServerPath() . $fileName,
+			$this->getServerPath(true) . $fileName,
 			$folder->getFilename() . $fileName
 		);
 		$file->ParentID = $folder->ID;
@@ -154,12 +154,15 @@ class WkFile {
 	}
 
 	/**
+	 * @param $trailSlash
+	 * 
 	 * @return string
 	 */
-	public function getServerPath() {
-		return Path::normalise(
+	public function getServerPath(bool $trailSlash = false) {
+		$path = Path::normalise(
 			ASSETS_PATH . DIRECTORY_SEPARATOR . $this->getFolder()->getFilename()
 		);
+		return $trailSlash ? $path . DIRECTORY_SEPARATOR : $path;
 	}
 
 	/**
@@ -176,7 +179,7 @@ class WkFile {
 		if (!$template) {
 			$parts = explode('\\', $obj->ClassName);
 
-			if (count($parts > 1)) {
+			if (count($parts) > 1) {
 				$last = $parts[count($parts) - 1];
 				unset($parts[count($parts) - 1]);
 				$parts[] = $type;

--- a/src/WkPdf.php
+++ b/src/WkPdf.php
@@ -131,18 +131,28 @@ class WkPdf extends WkFile {
 	 * @param string $fileName
 	 * @param string $fileClass
 	 * @param array  $extraData
+	 * @param bool $unlinkOnCreate
 	 *
 	 * @return mixed
 	 */
-	public function save(string $fileName, string $fileClass = File::class, array $extraData = []) {
+	public function save(
+		string $fileName, 
+		string $fileClass = File::class, 
+		array $extraData = [], 
+		bool $unlinkOnCreate = false
+	) {
 		$pdf = $this->getPdf();
 		$fileName = $this->generateValidFileName($fileName, 'pdf');
-		$serverPath = $this->getServerPath();
+		$serverPath = $this->getServerPath(true);
 
 		if (!$pdf->saveAs($serverPath . $fileName)) {
 			$this->handleError($pdf);
 		} else {
-			return $this->createFile($fileName, $fileClass, $extraData);
+			$file = $this->createFile($fileName, $fileClass, $extraData);
+			if ($file && $unlinkOnCreate) {
+				@unlink($serverPath . $fileName);
+			}
+			return $file;
 		}
 	}
 


### PR DESCRIPTION
ADD: param to include trailing slash for server path, and set `save()` and `createFile()` methods to include the trailing slash.

ADD: option to unlink the initial saved PDF after the file is created in the asset store (if the store file is created with a version suffix, it's difficult to unlink from code outside the module)
